### PR TITLE
chore(robots): disallow search engine indexing on test site

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
Disallow search engines from indexing the test/preview environment (cobsea-test.akvotest.org). Production is served from the separate cobsea-prod fork and is unaffected.